### PR TITLE
Fix tests failing because of current date time

### DIFF
--- a/NDB.Covid19/NDB.Covid19.Test/Tests/ExposureNotification/PullKeysTests.cs
+++ b/NDB.Covid19/NDB.Covid19.Test/Tests/ExposureNotification/PullKeysTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace NDB.Covid19.Test.Tests.ExposureNotification
 {
-    public class PullKeysTests
+    public class PullKeysTests : IDisposable
     {
         private readonly IDeveloperToolsService _developerTools;
         private readonly ZipDownloaderHelper _helper;
@@ -58,6 +58,12 @@ namespace NDB.Covid19.Test.Tests.ExposureNotification
             _preferences.Clear();
             _logManager.DeleteAll();
             _developerTools.ClearAllFields();
+        }
+
+        public void Dispose()
+        {
+            //Reset system time
+            SystemTime.ResetDateTime();
         }
 
         [Theory]
@@ -943,7 +949,6 @@ namespace NDB.Covid19.Test.Tests.ExposureNotification
             //Clean up log
             await _logManager.DeleteAll();
         }
-
 
         private List<PullKeysMockData> SixteenDaysOfKeys()
         {

--- a/NDB.Covid19/NDB.Covid19.Test/Tests/ExposureNotification/ResendNotificationTests.cs
+++ b/NDB.Covid19/NDB.Covid19.Test/Tests/ExposureNotification/ResendNotificationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using CommonServiceLocator;
 using NDB.Covid19.Configuration;
 using NDB.Covid19.Enums;
@@ -25,6 +26,7 @@ namespace NDB.Covid19.Test.Tests.ExposureNotification
         {
             DependencyInjectionConfig.Init();
             _secureStorageService.SetSecureStorageInstance(new SecureStorageMock());
+            ResetData();
         }
 
         private static SecureStorageService _secureStorageService =>
@@ -81,14 +83,12 @@ namespace NDB.Covid19.Test.Tests.ExposureNotification
         [InlineData(14, -1, false, true)] // Before upper bound
         [InlineData(14, 0, false, true)] // Equal upper bound
         [InlineData(14, 1, false, true)] // After upper bound
-        public async void ShouldUpdateLastMessageDate(
+        public async Task ShouldUpdateLastMessageDate(
             int daysOfTimeShift,
             int minutesOfTimeShift,
             bool shouldBeCalled = false,
             bool isUpperBound = false)
         {
-            ResetData();
-
             SystemTime.SetDateTime(
                 DateTime.Now.Date.AddHours(Conf.HOUR_WHEN_MESSAGE_SHOULD_BE_RESEND_BEGIN - 1).ToUniversalTime());
             await ServiceLocator.Current.GetInstance<IMessagesManager>().SaveNewMessage(new MessageSQLiteModel
@@ -138,8 +138,6 @@ namespace NDB.Covid19.Test.Tests.ExposureNotification
                 preFetchDateTime <
                 MessageUtils.GetDateTimeFromSecureStorageForKey(SecureStorageKeys.LAST_SENT_NOTIFICATION_UTC_KEY, ""));
             Assert.Equal(shouldBeCalled, LocalNotificationsManager.HasBeenCalled[NotificationsEnum.NewMessageReceived]);
-
-            SystemTime.ResetDateTime();
         }
 
         private void ResetData()

--- a/NDB.Covid19/NDB.Covid19.Test/Tests/Utils/NTPDateTimeTests.cs
+++ b/NDB.Covid19/NDB.Covid19.Test/Tests/Utils/NTPDateTimeTests.cs
@@ -21,7 +21,7 @@ namespace NDB.Covid19.Test.Tests.Utils
         }
 
         [Fact]
-        public async void SystemDateTimeIsCorrect_ShouldUseSystemDateTime()
+        public void SystemDateTimeIsCorrect_ShouldUseSystemDateTime()
         {
             SystemTime.ResetDateTime();
             DateTime currentTime = DateTime.UtcNow;
@@ -49,15 +49,15 @@ namespace NDB.Covid19.Test.Tests.Utils
         }
 
         [Fact]
-        public async void SystemDateTimeIsIncorrect_NtpIsLowerThanCurrent_ShouldUseDefault()
+        public void SystemDateTimeIsIncorrect_NtpIsLowerThanCurrent_ShouldUseDefault()
         {
             SystemTime.ResetDateTime();
-            DateTime currentTime = DateTime.UtcNow.AddYears(-3);
-            SystemTime.SetDateTime(currentTime);
+            DateTime pastTime = Conf.DATE_TIME_REPLACEMENT.AddYears(-2).AddMonths(-1);
+            SystemTime.SetDateTime(pastTime);
 
             NTPUtcDateTime ntpUtcDateTime =
                 Mock.Of<NTPUtcDateTime>(ntp =>
-                    ntp.GetNTPUtcDateTime() == Task.FromResult(currentTime.AddYears(-1)));
+                    ntp.GetNTPUtcDateTime() == Task.FromResult(pastTime.AddYears(-1)));
 
             try
             {
@@ -80,11 +80,11 @@ namespace NDB.Covid19.Test.Tests.Utils
         }
 
         [Fact]
-        public async void SystemDateTimeIsIncorrect_NtpIsEqualToPersisted_ShouldUseDefault()
+        public void SystemDateTimeIsIncorrect_NtpIsEqualToPersisted_ShouldUseDefault()
         {
             SystemTime.ResetDateTime();
-            DateTime currentTime = DateTime.UtcNow.AddYears(-3);
-            SystemTime.SetDateTime(currentTime);
+            DateTime pastTime = Conf.DATE_TIME_REPLACEMENT.AddYears(-2).AddMonths(-1);
+            SystemTime.SetDateTime(pastTime);
 
             NTPUtcDateTime ntpUtcDateTime =
                 Mock.Of<NTPUtcDateTime>(ntp =>
@@ -114,8 +114,8 @@ namespace NDB.Covid19.Test.Tests.Utils
         public async void SystemDateTimeIsIncorrect_ShouldUseNTP()
         {
             SystemTime.ResetDateTime();
-            DateTime currentTime = DateTime.UtcNow.AddYears(-3);
-            SystemTime.SetDateTime(currentTime);
+            DateTime pastTime = Conf.DATE_TIME_REPLACEMENT.AddYears(-2).AddMonths(-1);
+            SystemTime.SetDateTime(pastTime);
 
             try
             {
@@ -135,7 +135,7 @@ namespace NDB.Covid19.Test.Tests.Utils
                     "message",
                     "additionalInfo");
 
-            Assert.True(currentTime < logModel.ReportedTime);
+            Assert.True(pastTime < logModel.ReportedTime);
 
             SystemTime.ResetDateTime();
         }
@@ -144,8 +144,8 @@ namespace NDB.Covid19.Test.Tests.Utils
         public async void SystemDateTimeIsIncorrectInTheFuture_ShouldUseNTP()
         {
             SystemTime.ResetDateTime();
-            DateTime currentTime = DateTime.UtcNow.AddYears(3);
-            SystemTime.SetDateTime(currentTime);
+            DateTime futureTime = Conf.DATE_TIME_REPLACEMENT.AddYears(2).AddMonths(1);
+            SystemTime.SetDateTime(futureTime);
 
             try
             {
@@ -165,7 +165,7 @@ namespace NDB.Covid19.Test.Tests.Utils
                     "message",
                     "additionalInfo");
 
-            Assert.True(currentTime > logModel.ReportedTime);
+            Assert.True(futureTime > logModel.ReportedTime);
 
             SystemTime.ResetDateTime();
         }


### PR DESCRIPTION
* Use static datatime in NTP tests instead of current time. Because comparison is with static date, so making it not relying on current date will keep it working.
* Reset system date time correctly.